### PR TITLE
DBの設定

### DIFF
--- a/src/main/java/oit/is/z0264/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z0264/kaizi/janken/security/JankenAuthConfiguration.java
@@ -40,6 +40,9 @@ public class JankenAuthConfiguration {
     http.formLogin();
     http.authorizeHttpRequests().mvcMatchers("/janken/**").authenticated();
     http.logout().logoutSuccessUrl("/");
+
+    http.csrf().disable();
+    http.headers().frameOptions().disable();
     return http.build();
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
-
+server.port=8080
+spring.sql.init.encoding=UTF-8
+spring.datasource.url=jdbc:h2:mem:janken
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled:true
+logging.level.root=INFO


### PR DESCRIPTION
・application.propertiesにデータベース関連の設定を実施
　　・server.portは8080とする(server.port=8080)
　　・spring.datasource.urlはjdbc:h2:mem:jankenに変更
　　・h2-consoleにアクセスできるようにspring.h2.console.enabled:trueを追加
・JankenAuthConfiguration.javaにh2-consoleにアクセスするための設定を追記